### PR TITLE
Fixed error listen() function

### DIFF
--- a/gocrafty/minecraft/listener.go
+++ b/gocrafty/minecraft/listener.go
@@ -77,16 +77,16 @@ func (l *Listener) Listen() (*Listener, error) {
 }
 
 func (l *Listener) listen() {
-	go func() {
-		ticker := time.NewTicker(time.Second * 4)
-		defer ticker.Stop()
-
-		for {
-			select {
-			case <-l.close:
-				return
-			}
+	for {
+		netConn, err := l.listener.Accept()
+		if err != nil {
+			l.logger.Errorf("Got an error accepting connection: %v", err)
+			continue
 		}
+
+		l.createConn(netConn)
+	}
+}
 	}()
 
 	defer func() {


### PR DESCRIPTION
Fixed an error in the listen() function :

- The first statement of the listen() function initializes a ticker, but it serves no purpose. There is no processing in the loop that follows.

- The loop that follows is intended to accept connections in a loop and create a new connection, but this loop is closed as soon as an error occurs. The return causes the goroutine to exit, and thus the listener to close. Instead, you should continue accepting connections, and if an error occurs, display an error message and move on to the next connection.